### PR TITLE
Remove ExternalPort from example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ $ docker run -d -p 1234:1234 \
              -e Name="DOCKER SERVER" \
              -e Mod=ra \
              -e ListenPort="1234" \
-             -e ExternalPort="1234" \
              --name openra \
              rmoriz/openra
 


### PR DESCRIPTION
The externalport parameter has been removed from the server & launch script, so isn't needed in the example. See https://github.com/OpenRA/OpenRA/pull/15458