### PR TITLE
Build images inside GitHub to fix ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: build
+
+on:
+  push:
+    branches: master
+
+jobs:
+   docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build openra
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7
+          push: true
+          tags: ghcr.io/davel/openra:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
I appreciate you might not wish to merge this as it replaces the build system, but it gets things working for me on a Raspberry Pi! You can see the end result here, https://github.com/users/davel/packages/container/package/openra

This change adds some workflow configuration to build the Docker images inside GitHub. This restores ARM builds.

It is set up to upload the images to GitHub's new package repository, but I believe you can tweak this to also upload to DockerHub; https://github.com/docker/build-push-action/blob/master/docs/advanced/push-multi-registries.md

You'll need to set up the `CR_PAT` access token for this to work with GitHub's package repository, poke me if you need directions.

Closes https://github.com/rmoriz/openra-dockerfile/issues/7
